### PR TITLE
Added drag and drop reordering for news incrusts

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,14 @@ app.use(bodyParser.urlencoded({ extended: false }))
 .use(express.static('./public'))
 .use('/api/emissions', emission)
 .use((err, req, res, next) => {
-  if(err) return res.status(500).send({ error: err });
+  if(err) {
+    console.error(`\n==== ERROR: ${(new Date).toLocaleString()} ====`);
+    console.error(err);
+    console.error("=================\n");
+    
+    return res.status(500).send({ error: err });
+  }
+
   next();
 });
 

--- a/public/emissions.html
+++ b/public/emissions.html
@@ -263,7 +263,7 @@
                 <div>
                     <label>Incrusts</label>
                     <div class="upload-incrust"><input v-on:paste="uploadIncrust"><img class="icon" src="assets/clippy.svg"></div>
-                    <draggable v-model="selectedNews.incrusts" class="incrust-container">
+                    <draggable v-model="selectedNews.incrusts" class="incrust-container" @change="updateNews(selectedNews)">
                         <div class="incrust" v-for="incrust in selectedNews.incrusts">
                             <img v-bind:src="incrust.path">
                             <a v-on:click="deleteIncrust(incrust)">X</a>

--- a/public/emissions.html
+++ b/public/emissions.html
@@ -268,7 +268,7 @@
                             <img v-bind:src="incrust">
                         </label> -->
                         <div class="incrust" v-for="incrust in selectedNews.incrusts">
-                            <img v-bind:src="incrust">
+                            <img v-bind:src="incrust.path">
                             <a v-on:click="deleteIncrust(incrust)">X</a>
                         </div>
                     </div>

--- a/public/emissions.html
+++ b/public/emissions.html
@@ -263,15 +263,12 @@
                 <div>
                     <label>Incrusts</label>
                     <div class="upload-incrust"><input v-on:paste="uploadIncrust"><img class="icon" src="assets/clippy.svg"></div>
-                    <div class="incrust-container">
-                        <!-- <label v-for="(incrust, indexIncrust) in selectedNews.incrusts">
-                            <img v-bind:src="incrust">
-                        </label> -->
+                    <draggable v-model="selectedNews.incrusts" class="incrust-container">
                         <div class="incrust" v-for="incrust in selectedNews.incrusts">
                             <img v-bind:src="incrust.path">
                             <a v-on:click="deleteIncrust(incrust)">X</a>
                         </div>
-                    </div>
+                    </draggable>
                 </div>
                 <div>
                     <button v-on:click="updateNews(selectedNews)">Mettre à jour</button>

--- a/routes/news.js
+++ b/routes/news.js
@@ -60,7 +60,6 @@ router.put('/:news', (req, res, next) => {
     // Map the incrusts back to an array of objectIds
     req.body.incrusts = req.body.incrusts.map(incrust => incrust.id);
 
-    delete req.body['incrusts']; // on ne veut pas mettre à jour les incrusts
     News.findOneAndUpdate({
         _id: req.news._id
     }, req.body, { new: true }, (err, n) => {

--- a/routes/news.js
+++ b/routes/news.js
@@ -9,10 +9,16 @@ router.get('/', (req, res, next) => {
     News.find({
         episode: req.episode._id
     }, null, { sort: { 'numero': 1 } }).lean().exec((err, news) => {
-
         news.forEach(n => {
-            n.incrusts = n.incrusts.map(incrust => path.join(req.originalUrl, n.numero.toString(), 'incrusts', incrust.toString()));
+            // Map the incrusts to build their URI while keeping their ID
+            n.incrusts = n.incrusts.map(incrust => {
+                return { 
+                    "path": path.join(req.originalUrl, n.numero.toString(), 'incrusts', incrust.toString()),
+                    "id": incrust
+                };
+            });
         });
+
         if (err) return next(err);
         res.send(news);
     });
@@ -51,6 +57,9 @@ router.get('/:news', (req, res) => {
 })
 
 router.put('/:news', (req, res, next) => {
+    // Map the incrusts back to an array of objectIds
+    req.body.incrusts = req.body.incrusts.map(incrust => incrust.id);
+
     delete req.body['incrusts']; // on ne veut pas mettre à jour les incrusts
     News.findOneAndUpdate({
         _id: req.news._id


### PR DESCRIPTION
Resolves #10 .
Pour expliquer : j'ai mappé les incrusts vers un array contenant le path et l'ID pour pouvoir ensuite récupérer l'ID au moment de mettre la news à jour. De cette manière, l'array d'objectIDs du modèle News peut être sauvegardé. Je m'en suis ensuite servi pour enregistrer l'ordre des incrustations.
Ainsi, pas besoin de sauvegarder l'ordre à l'intérieur des incrusts et on gagne en nombre de requêtes à mongo.